### PR TITLE
Fixed navbar links

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,4 +1,4 @@
 <!-- _navbar.md -->
 
--   [Releases](https://github.com/JujuAdams/Input/releases)
--   [Report a bug](https://github.com/JujuAdams/Input/issues)
+-   [Releases](https://github.com/JujuAdams/Bulb/releases)
+-   [Report a bug](https://github.com/JujuAdams/Bulb/issues)


### PR DESCRIPTION
I was actually browsing Bulbs documentation earlier trying to integrate it into a side project, when I realized that both the releases and "report a bug" links point to Input...

This PR just changes it to bulbs repo.